### PR TITLE
Check for sale_payment before getting sale in get_shipping_address #6859

### DIFF
--- a/sale.py
+++ b/sale.py
@@ -439,7 +439,7 @@ class PaymentTransaction:
     )
 
     def get_shipping_address(self, name):
-        return self.sale_payment.sale and \
+        return self.sale_payment and self.sale_payment.sale and \
             self.sale_payment.sale.shipment_address.id
 
 


### PR DESCRIPTION
sale_payment may be made not required by downstream module; so, not
assuming that sale_payment is always there.