### PR TITLE
sale_payment in transaction should not be required #6859

### DIFF
--- a/sale.py
+++ b/sale.py
@@ -434,8 +434,7 @@ class PaymentTransaction:
     __name__ = 'payment_gateway.transaction'
 
     sale_payment = fields.Many2One(
-        'sale.payment', 'Sale Payment', required=True, ondelete='RESTRICT',
-        select=True,
+        'sale.payment', 'Sale Payment', ondelete='RESTRICT', select=True,
     )
 
     def get_shipping_address(self, name):


### PR DESCRIPTION
Payment can be for anything, not necessarily for sale